### PR TITLE
API URL does not need to be secret.

### DIFF
--- a/kubernetes/Secrets/metal-secret.yaml
+++ b/kubernetes/Secrets/metal-secret.yaml
@@ -8,5 +8,4 @@ metadata:
 data:
   userData: ""
   metalAPIKey: Z2VoZWltCg== # metal API key (base64 encoded)
-  metalAPIURL: bWV0YWwudGVzdC5maS10cy5pbwo= # created with echo <metal-api-url> | base64
 type: Opaque

--- a/kubernetes/machine_classes/metal-machine-class.yaml
+++ b/kubernetes/machine_classes/metal-machine-class.yaml
@@ -6,6 +6,7 @@ metadata:
   name: test-metal # Name of metal machine class goes here
   namespace: default # Namespace in which the machine class is to be deployed
 spec:
+  apiURL: https://metal-api-endpoint
   tenant: "Metal Cooperation"
   project: "gardener-test" # UUID of a project with which you have rights
   image: ubuntu-19.04 # OS ID or slug goes here

--- a/pkg/apis/machine/types.go
+++ b/pkg/apis/machine/types.go
@@ -1180,6 +1180,7 @@ type MetalMachineClassList struct {
 
 // MetalMachineClassSpec is the specification of a cluster.
 type MetalMachineClassSpec struct {
+	APIURL    string
 	Partition string // required
 	Size      string // required
 	Image     string // required

--- a/pkg/apis/machine/v1alpha1/types.go
+++ b/pkg/apis/machine/v1alpha1/types.go
@@ -1199,8 +1199,6 @@ const (
 	MetalAPIKey string = "metalAPIKey"
 	// MetalAPIHMac is a constant for a hmac that is part of the Metal cloud credentials
 	MetalAPIHMac string = "metalAPIHMac"
-	// MetalAPIURL is a constant for a url where to reach out the metal api
-	MetalAPIURL string = "metalAPIURL"
 )
 
 /********************** AlicloudMachineClass APIs ***************/
@@ -1339,6 +1337,7 @@ type MetalMachineClassList struct {
 
 // MetalMachineClassSpec is the specification of a cluster.
 type MetalMachineClassSpec struct {
+	APIURL    string   `json:"apiURL"`
 	Partition string   `json:"partition"`
 	Size      string   `json:"size"`
 	Image     string   `json:"image"`

--- a/pkg/driver/driver_metal.go
+++ b/pkg/driver/driver_metal.go
@@ -210,11 +210,7 @@ func (d *MetalDriver) createSVC() (*metalgo.Driver, error) {
 	token := strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.MetalAPIKey]))
 	hmac := strings.TrimSpace(string(d.CloudConfig.Data[v1alpha1.MetalAPIHMac]))
 
-	u, ok := d.CloudConfig.Data[v1alpha1.MetalAPIURL]
-	if !ok {
-		return nil, fmt.Errorf("missing %s in secret", v1alpha1.MetalAPIURL)
-	}
-	url := strings.TrimSpace(string(u))
+	url := strings.TrimSpace(string(d.MetalMachineClass.Spec.APIURL))
 
 	return metalgo.NewDriver(url, token, hmac)
 }


### PR DESCRIPTION
Instead, make it part of the machine class spec.

References https://github.com/metal-stack/gardener-extension-provider-metal/issues/63.